### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
+        dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x        
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Represents the **NuGet** versions.
 
+## v2.0.0
+- *Enhancement:* **Breaking change** - underlying JSON serialization has been changed from `Newtonsoft.Json` to `System.Text.Json`, with new `Utility.JsonSerializer` encapsulating logic to enable. The following steps are required to migrate existing usage:
+  - Rename all attribute references from `JsonProperty` to `JsonPropertyName`.
+  - Remove all attribute references to `[JsonObject(MemberSerialization = MemberSerialization.OptIn)]`; opt-in is the default behavior when leveraging the `CodeGenClassAttribute` attribute.
+- *Fixed:* All dependencies updated to the latest version.
+
 ## v1.0.8
 - *Fixed:* Added comparison context where reporting a file update as a result of using `ExpectNoChanges`.
 

--- a/src/OnRamp/Config/CodeGenPropertyAttribute.cs
+++ b/src/OnRamp/Config/CodeGenPropertyAttribute.cs
@@ -7,19 +7,14 @@ namespace OnRamp.Config
     /// <summary>
     /// Represents the <i>code-generation</i> property configuration.
     /// </summary>
+    /// <param name="category">The grouping category.</param>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
-    public sealed class CodeGenPropertyAttribute : Attribute
+    public sealed class CodeGenPropertyAttribute(string category) : Attribute
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CodeGenPropertyAttribute"/> class.
-        /// </summary>
-        /// <param name="category">The grouping category.</param>
-        public CodeGenPropertyAttribute(string category) => Category = category ?? throw new ArgumentNullException(nameof(category));
-
         /// <summary>
         /// Gets or sets the category.
         /// </summary>
-        public string Category { get; }
+        public string Category { get; } = category ?? throw new ArgumentNullException(nameof(category));
 
         /// <summary>
         /// Gets or sets the title.

--- a/src/OnRamp/Config/ConfigBase.cs
+++ b/src/OnRamp/Config/ConfigBase.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace OnRamp.Config
@@ -13,7 +13,6 @@ namespace OnRamp.Config
     /// <summary>
     /// Provides base configuration capabilities.
     /// </summary>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public abstract class ConfigBase
     {
         #region static
@@ -215,35 +214,35 @@ namespace OnRamp.Config
         /// Gets or sets the <see cref="Dictionary{TKey, TValue}"/> that houses any additional/extra properties/attributes deserialized within the configuration.
         /// </summary>
         [JsonExtensionData]
-        public Dictionary<string, JToken>? ExtraProperties { get; set; }
+        public Dictionary<string, JsonElement>? ExtraProperties { get; set; }
 
         /// <summary>
-        /// Gets the property value from <see cref="ExtraProperties"/> using the specified <paramref name="key"/> as <see cref="Type"/> <typeparamref name="T"/>.
+        /// Gets the property value from <see cref="ExtraProperties"/> using the specified <paramref name="key"/> and <see cref="Type"/> <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The property <see cref="Type"/>.</typeparam>
         /// <param name="key">The key.</param>
         /// <param name="defaultValue">The default value where the property is not found.</param>
         /// <returns>The value.</returns>
-        public T GetExtraProperty<T>(string key, T defaultValue = default!) where T : JToken
+        public T? GetExtraProperty<T>(string key, T? defaultValue = default!)
         {
             if (ExtraProperties != null && ExtraProperties.TryGetValue(key, out var val))
-                return (T)Convert.ChangeType(val, typeof(T));
+                return val.Deserialize<T>()!;
             else
                 return defaultValue!;
         }
 
         /// <summary>
-        /// Trys to get the property value from <see cref="ExtraProperties"/> using the specified <paramref name="key"/> as <see cref="Type"/> <typeparamref name="T"/>.
+        /// Trys to get the property value from <see cref="ExtraProperties"/> using the specified <paramref name="key"/> and <see cref="Type"/> <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The property <see cref="Type"/>.</typeparam>
         /// <param name="key">The key.</param>
         /// <param name="value">The corresponding value.</param>
         /// <returns><c>true</c> if the <paramref name="key"/> is found; otherwise, <c>false</c>.</returns>
-        public bool TryGetExtraProperty<T>(string key, out T value) where T : JToken
+        public bool TryGetExtraProperty<T>(string key, out T value)
         {
             if (ExtraProperties != null && ExtraProperties.TryGetValue(key, out var val))
             {
-                value = (T)Convert.ChangeType(val, typeof(T));
+                value = val.Deserialize<T>()!;
                 return true;
             }
             else
@@ -257,7 +256,7 @@ namespace OnRamp.Config
         /// Gets the <see cref="Dictionary{TKey, TValue}"/> that allows for custom property values to be manipulated at runtime.
         /// </summary>
         [JsonIgnore]
-        public Dictionary<string, object> CustomProperties { get; } = new Dictionary<string, object>();
+        public Dictionary<string, object> CustomProperties { get; } = [];
 
         /// <summary>
         /// Gets the property value from <see cref="CustomProperties"/> using the specified <paramref name="key"/> as <see cref="Type"/> <typeparamref name="T"/>.

--- a/src/OnRamp/Config/ConfigBaseT.cs
+++ b/src/OnRamp/Config/ConfigBaseT.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +13,6 @@ namespace OnRamp.Config
     /// </summary>
     /// <typeparam name="TRoot">The root <see cref="Type"/>.</typeparam>
     /// <typeparam name="TParent">The parent <see cref="Type"/>.</typeparam>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public abstract class ConfigBase<TRoot, TParent> : ConfigBase where TRoot : ConfigBase where TParent : ConfigBase
     {
         /// <summary>

--- a/src/OnRamp/Config/ConfigRootBase.cs
+++ b/src/OnRamp/Config/ConfigRootBase.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
 using OnRamp.Generators;
 using System;
 using System.Collections.Generic;
@@ -11,7 +10,6 @@ namespace OnRamp.Config
     /// Provides the <b>root</b> base <see cref="ConfigBase.PrepareAsync(object, object)"/> configuration capabilities.
     /// </summary>
     /// <typeparam name="TRoot">The root <see cref="Type"/>.</typeparam>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public abstract class ConfigRootBase<TRoot> : ConfigBase<TRoot, TRoot>, IRootConfig where TRoot : ConfigRootBase<TRoot>
     {
         /// <summary>

--- a/src/OnRamp/Console/ConsoleLogger.cs
+++ b/src/OnRamp/Console/ConsoleLogger.cs
@@ -20,13 +20,13 @@ namespace OnRamp.Console
         public ConsoleLogger(IConsole? console = null) => _console = console;
 
         /// <inheritdoc />
-        public IDisposable BeginScope<TState>(TState state) => NullScope.Default;
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Default;
 
         /// <inheritdoc />
         public bool IsEnabled(LogLevel logLevel) => true;
 
         /// <inheritdoc />
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {
             if (formatter == null)
                 throw new ArgumentNullException(nameof(formatter));

--- a/src/OnRamp/OnRamp.csproj
+++ b/src/OnRamp/OnRamp.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>OnRamp</RootNamespace>
-    <Version>1.0.8</Version>
+    <Version>2.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Avanade</Authors>
     <Company>Avanade</Company>
@@ -48,13 +48,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Handlebars.Net" Version="2.0.9" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.4" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Pluralize.NET" Version="1.0.2" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
 
 </Project>

--- a/src/OnRamp/Scripts/CodeGenScript.cs
+++ b/src/OnRamp/Scripts/CodeGenScript.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
 using OnRamp.Config;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace OnRamp.Scripts
@@ -12,7 +12,6 @@ namespace OnRamp.Scripts
     /// <summary>
     /// Represents the root that encapsulates the underlying <see cref="Generators"/>.
     /// </summary>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     [CodeGenClass("Script", Title = "'Script' object.", Description = "The `Script` object scripts the code-generation execution.")]
     [CodeGenCategory("Key", Title = "Provides the _Key_ configuration.")]
     [CodeGenCategory("Collections", Title = "Provides related child (hierarchical) configuration.")]
@@ -24,28 +23,28 @@ namespace OnRamp.Scripts
         /// <summary>
         /// Gets or sets the .NET <see cref="ConfigRootBase{TRoot}"/> Type for the underlying <see cref="Generators"/>.
         /// </summary>
-        [JsonProperty("configType")]
+        [JsonPropertyName("configType")]
         [CodeGenProperty("Key", Title = "The .NET ConfigRootBase Type for the underlying 'Generators'.", IsMandatory = true)]
         public string? ConfigType { get; set; }
 
         /// <summary>
         /// Gets or sets the list of additional script resource names to inherit.
         /// </summary>
-        [JsonProperty("inherits")]
+        [JsonPropertyName("inherits")]
         [CodeGenPropertyCollection("Key", Title = "The list of additional script resource names to inherit.")]
         public List<string>? Inherits { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="IConfigEditor"/> <see cref="Type"/>.
         /// </summary>
-        [JsonProperty("editorType")]
+        [JsonPropertyName("editorType")]
         [CodeGenPropertyCollection("Key", Title = "The .NET IConfigEditor Type for performing extended custom configuration prior to generation.")]
         public string? EditorType { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="CodeGenScriptItem"/> collection.
         /// </summary>
-        [JsonProperty("generators")]
+        [JsonPropertyName("generators")]
         [CodeGenPropertyCollection("Collections", Title = "The corresponding `Generator` collection.")]
         public List<CodeGenScriptItem>? Generators { get; set; }
 

--- a/src/OnRamp/Scripts/CodeGenScriptItem.cs
+++ b/src/OnRamp/Scripts/CodeGenScriptItem.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
 using OnRamp.Config;
 using OnRamp.Generators;
 using OnRamp.Utility;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace OnRamp.Scripts
@@ -13,7 +13,6 @@ namespace OnRamp.Scripts
     /// <summary>
     /// Represents the <see cref="HandlebarsCodeGenerator"/> script arguments used to define a <see cref="CodeGeneratorBase"/> (as specified by the <see cref="Type"/>) and other associated code-generation arguments.
     /// </summary>
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     [CodeGenClass("Generate", Title = "'Generate' command.", Description = "The `Generate` command defines the execution parameters for a code-generation execution.")]
     [CodeGenCategory("Key", Title = "Provides the _Key_ configuration.")]
     public class CodeGenScriptItem : ConfigBase<CodeGenScript, CodeGenScript>
@@ -29,14 +28,14 @@ namespace OnRamp.Scripts
         /// <summary>
         /// Gets or sets the <see cref="CodeGeneratorBase"/> <see cref="System.Type"/>.
         /// </summary>
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         [CodeGenProperty("Key", Title = "The .NET Generator (CodeGeneratorBase) Type.", IsMandatory = true)]
         public string? Type { get; set; }
 
         /// <summary>
         /// Gets or sets the template resource name.
         /// </summary>
-        [JsonProperty("template")]
+        [JsonPropertyName("template")]
         [CodeGenProperty("Key", Title = "The template resource name.", IsMandatory = true)]
         public string? Template { get; set; }
 
@@ -44,7 +43,7 @@ namespace OnRamp.Scripts
         /// Gets or sets the file name.
         /// </summary>
         /// <remarks>Supports <b>Handlebars</b> syntax.</remarks>
-        [JsonProperty("file")]
+        [JsonPropertyName("file")]
         [CodeGenProperty("Key", Title = "The file name.", IsMandatory = true, Description = "Supports _Handlebars_ syntax.")]
         public string? File { get; set; }
 
@@ -52,14 +51,14 @@ namespace OnRamp.Scripts
         /// Gets or sets the directory name.
         /// </summary>
         /// <remarks>Supports <b>Handlebars</b> syntax.</remarks>
-        [JsonProperty("directory")]
+        [JsonPropertyName("directory")]
         [CodeGenProperty("Key", Title = "The directory name.", Description = "Supports _Handlebars_ syntax.")]
         public string? Directory { get; set; }
 
         /// <summary>
         /// Indicates whether the file is only generated once; i.e. only created where it does not already exist.
         /// </summary>
-        [JsonProperty("genOnce")]
+        [JsonPropertyName("genOnce")]
         [CodeGenProperty("Key", Title = "Indicates whether the file is only generated once; i.e. only created where it does not already exist.")]
         public bool IsGenOnce { get; set; }
 
@@ -67,14 +66,14 @@ namespace OnRamp.Scripts
         /// Gets or sets the gen-once file name pattern to check (can include wildcard '<c>*</c>' characters).
         /// </summary>
         /// <remarks>Supports <b>Handlebars</b> syntax.</remarks>
-        [JsonProperty("genOncePattern")]
+        [JsonPropertyName("genOncePattern")]
         [CodeGenProperty("Key", Title = "The gen-once file name pattern to check (can include wildcard `*` characters).", Description = "Supports _Handlebars_ syntax. Defaults to `File` where not specified.")]
         public string? GenOncePattern { get; set; }
 
         /// <summary>
         /// Gets or sets the help text.
         /// </summary>
-        [JsonProperty("text")]
+        [JsonPropertyName("text")]
         [CodeGenProperty("Key", Title = "The additional text written to the log to enable additional context.")]
         public string? Text { get; set; }
 
@@ -127,7 +126,7 @@ namespace OnRamp.Scripts
                 {
                     foreach (var json in ExtraProperties)
                     {
-                        RuntimeParameters.Add(json.Key, json.Value.ToObject<string?>());
+                        RuntimeParameters.Add(json.Key, json.Value.ToString());
                     }
                 }
             }

--- a/src/OnRamp/Utility/JsonSerializer.cs
+++ b/src/OnRamp/Utility/JsonSerializer.cs
@@ -1,0 +1,76 @@
+﻿using OnRamp.Config;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace OnRamp.Utility
+{
+    /// <summary>
+    /// Provides customized JSON serialization.
+    /// </summary>
+    public static class JsonSerializer
+    {
+        /// <summary>
+        /// Provides the default <see cref="JsonSerializerOptions"/> including <see cref="OptInJsonTypeInfoResolver"/>.
+        /// </summary>
+        public static JsonSerializerOptions Options { get; } = new JsonSerializerOptions(JsonSerializerOptions.Default)
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+            WriteIndented = false,
+            TypeInfoResolver = new OptInJsonTypeInfoResolver()
+        };
+
+        /// <summary>
+        /// Support opt-in properties only (explicit <see cref="JsonPropertyNameAttribute"/>) where the class is marked with <see cref="CodeGenClassAttribute"/>; otherwise, all properties are included as per default behavior.
+        /// </summary>
+        public class OptInJsonTypeInfoResolver : DefaultJsonTypeInfoResolver
+        {
+            /// <inheritdoc/>
+            public override JsonTypeInfo GetTypeInfo(Type type, JsonSerializerOptions options)
+            {
+                var jti = base.GetTypeInfo(type, options);
+                if (jti.Kind == JsonTypeInfoKind.Object && jti.Type.GetCustomAttributes(typeof(CodeGenClassAttribute), true)?.Length > 0)
+                {
+                    var props = new List<JsonPropertyInfo>(jti.Properties);
+                    jti.Properties.Clear();
+
+                    foreach (var prop in props)
+                    {
+                        if (prop.IsExtensionData || (prop.AttributeProvider is not null && prop.AttributeProvider.GetCustomAttributes(typeof(JsonPropertyNameAttribute), true)?.Length > 0))
+                            jti.Properties.Add(prop);
+                    }
+                }
+
+                return jti;
+            }
+        }
+
+        /// <summary>
+        /// Deserializes the <paramref name="json"/> <see cref="Stream"/> into the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="json">The UTF8 JSON <see cref="Stream"/>.</param>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <returns>The resulting deserialized value.</returns>
+        public static object? Deserialize(Stream json, Type type) => System.Text.Json.JsonSerializer.Deserialize(json, type, Options);
+
+        /// <summary>
+        /// Deserializes the <paramref name="json"/> <see cref="TextReader"/> into the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="json">The UTF8 JSON <see cref="TextReader"/>.</param>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <returns>The resulting deserialized value.</returns>
+        public static object? Deserialize(TextReader json, Type type) => System.Text.Json.JsonSerializer.Deserialize(json.ReadToEnd(), type, Options);
+
+        /// <summary>
+        /// Deserializes the <paramref name="json"/> <see cref="string"/> into the specified <paramref name="type"/>.
+        /// </summary>
+        /// <param name="json">The UTF8 JSON <see cref="string"/>.</param>
+        /// <param name="type">The <see cref="Type"/>.</param>
+        /// <returns>The resulting deserialized value.</returns>
+        public static object? Deserialize(string json, Type type) => System.Text.Json.JsonSerializer.Deserialize(json, type, Options);
+    }
+}

--- a/src/OnRamp/Utility/MarkdownDocumentationGenerator.cs
+++ b/src/OnRamp/Utility/MarkdownDocumentationGenerator.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Avanade. Licensed under the MIT License. See https://github.com/Avanade/OnRamp
 
-using Newtonsoft.Json;
 using OnRamp.Config;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 
 namespace OnRamp.Utility
 {
@@ -49,7 +49,7 @@ namespace OnRamp.Utility
             var pdlist = new List<MarkdownDocumentationGeneratorPropertyData>();
             foreach (var pi in type.GetProperties())
             {
-                var jpa = pi.GetCustomAttribute<JsonPropertyAttribute>();
+                var jpa = pi.GetCustomAttribute<JsonPropertyNameAttribute>();
                 if (jpa == null)
                     continue;
 
@@ -57,7 +57,7 @@ namespace OnRamp.Utility
                 {
                     Type = type,
                     Class = csa,
-                    Name = jpa.PropertyName ?? StringConverter.ToCamelCase(pi.Name),
+                    Name = jpa.Name ?? StringConverter.ToCamelCase(pi.Name),
                     Property = pi,
                     Psa = pi.GetCustomAttribute<CodeGenPropertyAttribute>()
                 };

--- a/tests/OnRamp.Test/CodeGenConsoleTest.cs
+++ b/tests/OnRamp.Test/CodeGenConsoleTest.cs
@@ -18,7 +18,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("--help");
-            Assert.AreEqual(0, r);
+            Assert.That(r, Is.EqualTo(0));
         }
 
         [Test]
@@ -26,7 +26,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole(options: SupportedOptions.IsSimulation | SupportedOptions.ExpectNoChanges);
             var r = await c.RunAsync("--help");
-            Assert.AreEqual(0, r);
+            Assert.That(r, Is.EqualTo(0));
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-s");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-c");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-d ../../Bad");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-a NotExists");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-db");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace OnRamp.Test
         {
             var c = new CodeGenConsole(options: SupportedOptions.IsSimulation | SupportedOptions.ExpectNoChanges);
             var r = await c.RunAsync("-c ValidEntity.yaml");
-            Assert.AreEqual(1, r);
+            Assert.That(r, Is.EqualTo(1));
         }
 
         [Test]
@@ -83,7 +83,7 @@ namespace OnRamp.Test
             var a = CodeGeneratorArgs.Create<CodeGeneratorTest>("ValidEntity.yaml");
             var c = new CodeGenConsole(a);
             var r = await c.RunAsync();
-            Assert.AreEqual(2, r);
+            Assert.That(r, Is.EqualTo(2));
         }
 
         [Test]
@@ -95,22 +95,22 @@ namespace OnRamp.Test
             var a = CodeGeneratorArgs.Create<CodeGeneratorTest>("ValidEntity.yaml", "Data/ValidEntity.yaml").AddParameter("Directory", "XA300").AddParameter("AppName", "Zzz");
             var c = new CodeGenConsole(a);
             var r = await c.RunAsync();
-            Assert.AreEqual(0, r);
+            Assert.That(r, Is.EqualTo(0));
 
-            Assert.IsTrue(Directory.Exists("XA300"));
-            Assert.AreEqual(4, Directory.GetFiles("XA300").Length);
+            Assert.That(Directory.Exists("XA300"), Is.True);
+            Assert.That(Directory.GetFiles("XA300").Length, Is.EqualTo(4));
 
-            Assert.IsTrue(File.Exists("XA300/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("XA300/Person.txt"));
+            Assert.That(File.Exists("XA300/Person.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA300/Person.txt"), Is.EqualTo("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary"));
 
-            Assert.IsTrue(File.Exists("XA300/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("XA300/Name.txt"));
+            Assert.That(File.Exists("XA300/Name.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA300/Name.txt"), Is.EqualTo("Name: Person.Name, Type: string"));
 
-            Assert.IsTrue(File.Exists("XA300/Age.txt"));
-            Assert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("XA300/Age.txt"));
+            Assert.That(File.Exists("XA300/Age.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA300/Age.txt"), Is.EqualTo("Name: Person.Age, Type: int"));
 
-            Assert.IsTrue(File.Exists("XA300/Salary.txt"));
-            Assert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("XA300/Salary.txt"));
+            Assert.That(File.Exists("XA300/Salary.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA300/Salary.txt"), Is.EqualTo("Name: Person.Salary, Type: decimal?"));
         }
 
         [Test]
@@ -121,22 +121,22 @@ namespace OnRamp.Test
 
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-s ValidEntity.yaml -c Data/ValidEntity.yaml -p Directory=XA310 -p AppName=Zzz -a \"OnRamp.Test, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null\"");
-            Assert.AreEqual(0, r);
+            Assert.That(r, Is.EqualTo(0));
 
-            Assert.IsTrue(Directory.Exists("XA310"));
-            Assert.AreEqual(4, Directory.GetFiles("XA310").Length);
+            Assert.That(Directory.Exists("XA310"), Is.True);
+            Assert.That(Directory.GetFiles("XA310").Length, Is.EqualTo(4));
 
-            Assert.IsTrue(File.Exists("XA310/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("XA310/Person.txt"));
+            Assert.That(File.Exists("XA310/Person.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA310/Person.txt"), Is.EqualTo("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary"));
 
-            Assert.IsTrue(File.Exists("XA310/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("XA310/Name.txt"));
+            Assert.That(File.Exists("XA310/Name.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA310/Name.txt"), Is.EqualTo("Name: Person.Name, Type: string"));
 
-            Assert.IsTrue(File.Exists("XA310/Age.txt"));
-            Assert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("XA310/Age.txt"));
+            Assert.That(File.Exists("XA310/Age.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA310/Age.txt"), Is.EqualTo("Name: Person.Age, Type: int"));
 
-            Assert.IsTrue(File.Exists("XA310/Salary.txt"));
-            Assert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("XA310/Salary.txt"));
+            Assert.That(File.Exists("XA310/Salary.txt"), Is.True);
+            Assert.That(File.ReadAllText("XA310/Salary.txt"), Is.EqualTo("Name: Person.Salary, Type: decimal?"));
         }
 
         [Test]
@@ -148,33 +148,33 @@ namespace OnRamp.Test
             // Run and it should fail as it cannot create.
             var c = new CodeGenConsole();
             var r = await c.RunAsync("-s ValidEntity.yaml -c Data/ValidEntity.yaml -enc -p Directory=XA400 -p AppName=Zzz -a \"OnRamp.Test, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null\"");
-            Assert.AreEqual(3, r);
+            Assert.That(r, Is.EqualTo(3));
 
             // Run again and let it make changes.
             c = new CodeGenConsole();
             r = await c.RunAsync("-s ValidEntity.yaml -c Data/ValidEntity.yaml -p Directory=XA400 -p AppName=Zzz -a \"OnRamp.Test, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null\"");
-            Assert.AreEqual(0, r);
+            Assert.That(r, Is.EqualTo(0));
 
             // Change the file and run again and it should fail as it cannot update.
             var files = Directory.GetFiles("XA400");
-            Assert.AreNotEqual(0, files.Length);
+            Assert.That(files.Length, Is.Not.EqualTo(0));
 
             var content = File.ReadAllText(files.Last());
             File.WriteAllText(files.Last(), content + "X");
 
             c = new CodeGenConsole();
             r = await c.RunAsync("-s ValidEntity.yaml -c Data/ValidEntity.yaml -enc -p Directory=XA400 -p AppName=Zzz -a \"OnRamp.Test, Version=1.2.3.0, Culture=neutral, PublicKeyToken=null\"");
-            Assert.AreEqual(3, r);
+            Assert.That(r, Is.EqualTo(3));
         }
 
         [Test]
         public void C100_GetBaseExeDirectory()
         {
             var ed = Environment.CurrentDirectory;
-            Assert.IsTrue(ed.Contains(Path.Combine("bin", "debug"), StringComparison.InvariantCultureIgnoreCase) || ed.Contains(Path.Combine("bin", "release"), StringComparison.InvariantCultureIgnoreCase));
+            Assert.That(ed.Contains(Path.Combine("bin", "debug"), StringComparison.InvariantCultureIgnoreCase) || ed.Contains(Path.Combine("bin", "release"), StringComparison.InvariantCultureIgnoreCase), Is.True);
 
             ed = CodeGenConsole.GetBaseExeDirectory();
-            Assert.IsFalse(ed.Contains(Path.Combine("bin", "debug"), StringComparison.InvariantCultureIgnoreCase) || ed.Contains(Path.Combine("bin", "release"), StringComparison.InvariantCultureIgnoreCase));
+            Assert.That(ed.Contains(Path.Combine("bin", "debug"), StringComparison.InvariantCultureIgnoreCase) || ed.Contains(Path.Combine("bin", "release"), StringComparison.InvariantCultureIgnoreCase), Is.False);
         }
     }
 }

--- a/tests/OnRamp.Test/CodeGeneratorTest.cs
+++ b/tests/OnRamp.Test/CodeGeneratorTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -13,121 +14,121 @@ namespace OnRamp.Test
         public void A100_Script_DoesNotExist()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync<CodeGenerator>(new CodeGeneratorArgs("DoesNotExist.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'DoesNotExist.yaml' does not exist.", ex.Message);
+            ClassicAssert.AreEqual("Script 'DoesNotExist.yaml' does not exist.", ex.Message);
         }
 
         [Test]
         public void A110_Script_InvalidFileType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidFileType.xml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidFileType.xml' is invalid: Stream content type is not supported.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidFileType.xml' is invalid: Stream content type is not supported.", ex.Message);
         }
 
         [Test]
         public void A120_Script_InvalidYamlContent()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidYamlContent.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidYamlContent.yaml' is invalid: Error converting value \"<blah></blah>\" to type 'OnRamp.Scripts.CodeGenScript'. Path '', line 1, position 15.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidYamlContent.yaml' is invalid: The JSON value could not be converted to OnRamp.Scripts.CodeGenScript. Path: $ | LineNumber: 0 | BytePositionInLine: 15.", ex.Message);
         }
 
         [Test]
         public void A130_Script_InvalidJsonContent()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidJsonContent.json").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidJsonContent.json' is invalid: Unexpected character encountered while parsing value: <. Path '', line 0, position 0.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidJsonContent.json' is invalid: '<' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 0.", ex.Message);
         }
 
         [Test]
         public void A140_Script_InvalidEmpty()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidEmpty.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidEmpty.yaml' is invalid: Stream is empty.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidEmpty.yaml' is invalid: Stream is empty.", ex.Message);
         }
 
         [Test]
         public void A150_Script_InvalidEmptyConfigType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidEmptyConfigType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidEmptyConfigType.yaml' is invalid: [ConfigType] Value is mandatory.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidEmptyConfigType.yaml' is invalid: [ConfigType] Value is mandatory.", ex.Message);
         }
 
         [Test]
         public void A160_Script_InvalidConfigType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InvalidConfigType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InvalidConfigType.yaml' is invalid: [ConfigType] Type 'OnRamp.Scripts.CodeGenScriptItem' must inherit from ConfigRootBase<TRoot>.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InvalidConfigType.yaml' is invalid: [ConfigType] Type 'OnRamp.Scripts.CodeGenScriptItem' must inherit from ConfigRootBase<TRoot>.", ex.Message);
         }
 
         [Test]
         public void B100_Generator_DoesNotExist()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("GeneratorDoesNotExist.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'GeneratorDoesNotExist.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.DoesNotExist, OnRamp.Test' does not exist.", ex.Message);
+            ClassicAssert.AreEqual("Script 'GeneratorDoesNotExist.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.DoesNotExist, OnRamp.Test' does not exist.", ex.Message);
         }
 
         [Test]
         public void B110_Generator_DiffConfigType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("GeneratorDiffConfigType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'GeneratorDiffConfigType.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.ScriptsGenerator, OnRamp.Test' RootType 'CodeGenScript' must be the same as the ConfigType 'EntityConfig'.", ex.Message);
+            ClassicAssert.AreEqual("Script 'GeneratorDiffConfigType.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.ScriptsGenerator, OnRamp.Test' RootType 'CodeGenScript' must be the same as the ConfigType 'EntityConfig'.", ex.Message);
         }
 
         [Test]
         public void B120_Generator_NotInherits()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("GeneratorNotInherits.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'GeneratorNotInherits.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.NotInheritsGenerator, OnRamp.Test' does not implement CodeGeneratorBase and/or have a default parameterless constructor.", ex.Message);
+            ClassicAssert.AreEqual("Script 'GeneratorNotInherits.yaml' is invalid: [Generate.Type] Type 'OnRamp.Test.Generators.NotInheritsGenerator, OnRamp.Test' does not implement CodeGeneratorBase and/or have a default parameterless constructor.", ex.Message);
         }
 
         [Test]
         public void B130_Generator_TemplateDoesNotExist()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("GeneratorTemplateDoesNotExist.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'GeneratorTemplateDoesNotExist.yaml' is invalid: [Generate.Template] Template 'DoesNotExist.hbs' does not exist.", ex.Message);
+            ClassicAssert.AreEqual("Script 'GeneratorTemplateDoesNotExist.yaml' is invalid: [Generate.Template] Template 'DoesNotExist.hbs' does not exist.", ex.Message);
         }
 
         [Test]
         public async Task B140_Generator_RuntimeParams()
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("GeneratorRuntimeParams.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
-            Assert.NotNull(cg);
-            Assert.NotNull(cg.Scripts?.Generators);
-            Assert.AreEqual(1, cg.Scripts.Generators.Count);
-            Assert.AreEqual(3, cg.Scripts.Generators[0].RuntimeParameters.Count);
-            Assert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("IsGenOnce"));
-            Assert.AreEqual(false, cg.Scripts.Generators[0].RuntimeParameters["IsGenOnce"]);
-            Assert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("Company"));
-            Assert.AreEqual("Xxx", cg.Scripts.Generators[0].RuntimeParameters["Company"]);
-            Assert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("AppName"));
-            Assert.AreEqual("Yyy", cg.Scripts.Generators[0].RuntimeParameters["AppName"]);
+            ClassicAssert.NotNull(cg);
+            ClassicAssert.NotNull(cg.Scripts?.Generators);
+            ClassicAssert.AreEqual(1, cg.Scripts.Generators.Count);
+            ClassicAssert.AreEqual(3, cg.Scripts.Generators[0].RuntimeParameters.Count);
+            ClassicAssert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("IsGenOnce"));
+            ClassicAssert.AreEqual(false, cg.Scripts.Generators[0].RuntimeParameters["IsGenOnce"]);
+            ClassicAssert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("Company"));
+            ClassicAssert.AreEqual("Xxx", cg.Scripts.Generators[0].RuntimeParameters["Company"]);
+            ClassicAssert.IsTrue(cg.Scripts.Generators[0].RuntimeParameters.ContainsKey("AppName"));
+            ClassicAssert.AreEqual("Yyy", cg.Scripts.Generators[0].RuntimeParameters["AppName"]);
         }
 
         [Test]
         public void C100_Inherits_DiffConfigType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("InheritsDiffConfigType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'InheritsDiffConfigType.yaml' is invalid: Script 'InheritsDiffConfigType2.yaml' is invalid: [ConfigType] Inherited ConfigType 'OnRamp.Test.Config.InheritAlternateConfigType, OnRamp.Test' must be the same as root ConfigType 'OnRamp.Scripts.CodeGenScript'.", ex.Message);
+            ClassicAssert.AreEqual("Script 'InheritsDiffConfigType.yaml' is invalid: Script 'InheritsDiffConfigType2.yaml' is invalid: [ConfigType] Inherited ConfigType 'OnRamp.Test.Config.InheritAlternateConfigType, OnRamp.Test' must be the same as root ConfigType 'OnRamp.Scripts.CodeGenScript'.", ex.Message);
         }
 
         [Test]
         public async Task C110_Inherits_SameConfigType()
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("InheritsSameConfigType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
-            Assert.NotNull(cg);
+            ClassicAssert.NotNull(cg);
         }
 
         [Test]
         public void D100_Editor_TypeNotFound()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("EditorTypeNotFound.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'EditorTypeNotFound.yaml' is invalid: [EditorType] Type 'OnRamp.Scripts.NotFound' does not exist.", ex.Message);
+            ClassicAssert.AreEqual("Script 'EditorTypeNotFound.yaml' is invalid: [EditorType] Type 'OnRamp.Scripts.NotFound' does not exist.", ex.Message);
         }
 
         [Test]
         public void D110_Editor_InvalidType()
         {
             var ex = Assert.ThrowsAsync<CodeGenException>(() => CodeGenerator.CreateAsync(new CodeGeneratorArgs("EditorInvalidType.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly)));
-            Assert.AreEqual("Script 'EditorInvalidType.yaml' is invalid: [EditorType] Type 'OnRamp.Scripts.CodeGenScript' does not implement IConfigEditor and/or have a default parameterless constructor.", ex.Message);
+            ClassicAssert.AreEqual("Script 'EditorInvalidType.yaml' is invalid: [EditorType] Type 'OnRamp.Scripts.CodeGenScript' does not implement IConfigEditor and/or have a default parameterless constructor.", ex.Message);
         }
 
         [Test]
@@ -135,7 +136,7 @@ namespace OnRamp.Test
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
             var ex = Assert.ThrowsAsync<CodeGenException>(() => cg.GenerateAsync("DoesNotExist.yaml"));
-            Assert.AreEqual("Config 'DoesNotExist.yaml' does not exist.", ex.Message);
+            ClassicAssert.AreEqual("Config 'DoesNotExist.yaml' does not exist.", ex.Message);
         }
 
         [Test]
@@ -143,7 +144,7 @@ namespace OnRamp.Test
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
             var ex = Assert.ThrowsAsync<CodeGenException>(() => cg.GenerateAsync("Data/InvalidFileType.xml"));
-            Assert.AreEqual("Config 'Data/InvalidFileType.xml' is invalid: Stream content type is not supported.", ex.Message);
+            ClassicAssert.AreEqual("Config 'Data/InvalidFileType.xml' is invalid: Stream content type is not supported.", ex.Message);
         }
 
         [Test]
@@ -151,7 +152,7 @@ namespace OnRamp.Test
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
             var ex = Assert.ThrowsAsync<CodeGenException>(() => cg.GenerateAsync("Data/MandatoryValue.yaml"));
-            Assert.AreEqual("Config 'Data/MandatoryValue.yaml' is invalid: [Property.Name] Value is mandatory.", ex.Message);
+            ClassicAssert.AreEqual("Config 'Data/MandatoryValue.yaml' is invalid: [Property.Name] Value is mandatory.", ex.Message);
         }
 
         [Test]
@@ -159,7 +160,7 @@ namespace OnRamp.Test
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity").AddAssembly(typeof(CodeGeneratorTest).Assembly));
             var ex = Assert.ThrowsAsync<CodeGenException>(() => cg.GenerateAsync("Data/InvalidOption.yaml"));
-            Assert.AreEqual("Config 'Data/InvalidOption.yaml' is invalid: [Property(Name='Salary').Type] Value 'unknown' is invalid; valid values are: 'string', 'int', 'decimal'.", ex.Message);
+            ClassicAssert.AreEqual("Config 'Data/InvalidOption.yaml' is invalid: [Property(Name='Salary').Type] Value 'unknown' is invalid; valid values are: 'string', 'int', 'decimal'.", ex.Message);
         }
 
         [Test]
@@ -167,7 +168,7 @@ namespace OnRamp.Test
         {
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly));
             var ex = Assert.ThrowsAsync<CodeGenException>(() => cg.GenerateAsync("Data/NonUniqueValue.yaml"));
-            Assert.AreEqual("Config 'Data/NonUniqueValue.yaml' is invalid: [Property(Name='Amount').Name] Value 'Amount' is not unique.", ex.Message);
+            ClassicAssert.AreEqual("Config 'Data/NonUniqueValue.yaml' is invalid: [Property(Name='Amount').Name] Value 'Amount' is not unique.", ex.Message);
         }
 
         [Test]
@@ -179,27 +180,27 @@ namespace OnRamp.Test
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly).AddParameter("Directory", "F100").AddParameter("AppName", "Zzz"));
             var stats = await cg .GenerateAsync("Data/ValidEntity.yaml");
 
-            Assert.NotNull(stats);
-            Assert.AreEqual(4, stats.CreatedCount);
-            Assert.AreEqual(0, stats.UpdatedCount);
-            Assert.AreEqual(0, stats.NotChangedCount);
-            Assert.AreEqual(4, stats.LinesOfCodeCount);
-            Assert.NotNull(stats.ElapsedMilliseconds);
+            ClassicAssert.NotNull(stats);
+            ClassicAssert.AreEqual(4, stats.CreatedCount);
+            ClassicAssert.AreEqual(0, stats.UpdatedCount);
+            ClassicAssert.AreEqual(0, stats.NotChangedCount);
+            ClassicAssert.AreEqual(4, stats.LinesOfCodeCount);
+            ClassicAssert.NotNull(stats.ElapsedMilliseconds);
 
-            Assert.IsTrue(Directory.Exists("F100"));
-            Assert.AreEqual(4, Directory.GetFiles("F100").Length);
+            ClassicAssert.IsTrue(Directory.Exists("F100"));
+            ClassicAssert.AreEqual(4, Directory.GetFiles("F100").Length);
 
-            Assert.IsTrue(File.Exists("F100/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F100/Person.txt"));
+            ClassicAssert.IsTrue(File.Exists("F100/Person.txt"));
+            ClassicAssert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F100/Person.txt"));
 
-            Assert.IsTrue(File.Exists("F100/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F100/Name.txt"));
+            ClassicAssert.IsTrue(File.Exists("F100/Name.txt"));
+            ClassicAssert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F100/Name.txt"));
 
-            Assert.IsTrue(File.Exists("F100/Age.txt"));
-            Assert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F100/Age.txt"));
+            ClassicAssert.IsTrue(File.Exists("F100/Age.txt"));
+            ClassicAssert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F100/Age.txt"));
 
-            Assert.IsTrue(File.Exists("F100/Salary.txt"));
-            Assert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F100/Salary.txt"));
+            ClassicAssert.IsTrue(File.Exists("F100/Salary.txt"));
+            ClassicAssert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F100/Salary.txt"));
         }
 
         [Test]
@@ -215,27 +216,27 @@ namespace OnRamp.Test
             var cg = await CodeGenerator.CreateAsync(CodeGeneratorArgs.Create<CodeGeneratorTest>("ValidEntity.yaml").AddParameter("Directory", "F110").AddParameter("AppName", "Zzz"));
             var stats = await cg .GenerateAsync("Data/ValidEntity.yaml");
 
-            Assert.NotNull(stats);
-            Assert.AreEqual(2, stats.CreatedCount);
-            Assert.AreEqual(1, stats.UpdatedCount);
-            Assert.AreEqual(1, stats.NotChangedCount);
-            Assert.AreEqual(4, stats.LinesOfCodeCount);
-            Assert.NotNull(stats.ElapsedMilliseconds);
+            ClassicAssert.NotNull(stats);
+            ClassicAssert.AreEqual(2, stats.CreatedCount);
+            ClassicAssert.AreEqual(1, stats.UpdatedCount);
+            ClassicAssert.AreEqual(1, stats.NotChangedCount);
+            ClassicAssert.AreEqual(4, stats.LinesOfCodeCount);
+            ClassicAssert.NotNull(stats.ElapsedMilliseconds);
 
-            Assert.IsTrue(Directory.Exists("F110"));
-            Assert.AreEqual(4, Directory.GetFiles("F110").Length);
+            ClassicAssert.IsTrue(Directory.Exists("F110"));
+            ClassicAssert.AreEqual(4, Directory.GetFiles("F110").Length);
 
-            Assert.IsTrue(File.Exists("F110/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F110/Person.txt"));
+            ClassicAssert.IsTrue(File.Exists("F110/Person.txt"));
+            ClassicAssert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F110/Person.txt"));
 
-            Assert.IsTrue(File.Exists("F110/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F110/Name.txt"));
+            ClassicAssert.IsTrue(File.Exists("F110/Name.txt"));
+            ClassicAssert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F110/Name.txt"));
 
-            Assert.IsTrue(File.Exists("F110/Age.txt"));
-            Assert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F110/Age.txt"));
+            ClassicAssert.IsTrue(File.Exists("F110/Age.txt"));
+            ClassicAssert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F110/Age.txt"));
 
-            Assert.IsTrue(File.Exists("F110/Salary.txt"));
-            Assert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F110/Salary.txt"));
+            ClassicAssert.IsTrue(File.Exists("F110/Salary.txt"));
+            ClassicAssert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F110/Salary.txt"));
         }
 
         [Test]
@@ -251,24 +252,24 @@ namespace OnRamp.Test
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml") { IsSimulation = true }.AddAssembly(typeof(CodeGeneratorTest).Assembly).AddParameter("Directory", "F120").AddParameter("AppName", "Zzz"));
             var stats = await cg.GenerateAsync("Data/ValidEntity.yaml");
 
-            Assert.NotNull(stats);
-            Assert.AreEqual(2, stats.CreatedCount);
-            Assert.AreEqual(1, stats.UpdatedCount);
-            Assert.AreEqual(1, stats.NotChangedCount);
-            Assert.AreEqual(4, stats.LinesOfCodeCount);
-            Assert.NotNull(stats.ElapsedMilliseconds);
+            ClassicAssert.NotNull(stats);
+            ClassicAssert.AreEqual(2, stats.CreatedCount);
+            ClassicAssert.AreEqual(1, stats.UpdatedCount);
+            ClassicAssert.AreEqual(1, stats.NotChangedCount);
+            ClassicAssert.AreEqual(4, stats.LinesOfCodeCount);
+            ClassicAssert.NotNull(stats.ElapsedMilliseconds);
 
-            Assert.IsTrue(Directory.Exists("F120"));
-            Assert.AreEqual(2, Directory.GetFiles("F120").Length);
+            ClassicAssert.IsTrue(Directory.Exists("F120"));
+            ClassicAssert.AreEqual(2, Directory.GetFiles("F120").Length);
 
-            Assert.IsTrue(File.Exists("F120/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F120/Person.txt"));
+            ClassicAssert.IsTrue(File.Exists("F120/Person.txt"));
+            ClassicAssert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F120/Person.txt"));
 
-            Assert.IsTrue(File.Exists("F120/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: xxx", File.ReadAllText("F120/Name.txt"));
+            ClassicAssert.IsTrue(File.Exists("F120/Name.txt"));
+            ClassicAssert.AreEqual("Name: Person.Name, Type: xxx", File.ReadAllText("F120/Name.txt"));
 
-            Assert.IsFalse(File.Exists("F120/Age.txt"));
-            Assert.IsFalse(File.Exists("F120/Salary.txt"));
+            ClassicAssert.IsFalse(File.Exists("F120/Age.txt"));
+            ClassicAssert.IsFalse(File.Exists("F120/Salary.txt"));
         }
 
         [Test]
@@ -280,18 +281,18 @@ namespace OnRamp.Test
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntityWithConfigEditor.yaml").AddAssembly(typeof(CodeGeneratorTest).Assembly).AddParameter("Directory", "F130"));
             var stats = await cg.GenerateAsync("Data/ValidEntity.yaml");
 
-            Assert.NotNull(stats);
-            Assert.AreEqual(1, stats.CreatedCount);
-            Assert.AreEqual(0, stats.UpdatedCount);
-            Assert.AreEqual(0, stats.NotChangedCount);
-            Assert.AreEqual(1, stats.LinesOfCodeCount);
-            Assert.NotNull(stats.ElapsedMilliseconds);
+            ClassicAssert.NotNull(stats);
+            ClassicAssert.AreEqual(1, stats.CreatedCount);
+            ClassicAssert.AreEqual(0, stats.UpdatedCount);
+            ClassicAssert.AreEqual(0, stats.NotChangedCount);
+            ClassicAssert.AreEqual(1, stats.LinesOfCodeCount);
+            ClassicAssert.NotNull(stats.ElapsedMilliseconds);
 
-            Assert.IsTrue(Directory.Exists("F130"));
-            Assert.AreEqual(1, Directory.GetFiles("F130").Length);
+            ClassicAssert.IsTrue(Directory.Exists("F130"));
+            ClassicAssert.AreEqual(1, Directory.GetFiles("F130").Length);
 
-            Assert.IsTrue(File.Exists("F130/PERSON.txt"));
-            Assert.AreEqual("Name: PERSON, CompanyName: Xxx, AppName: Yyy, Properties: Name, Age, Salary", File.ReadAllText("F130/PERSON.txt"));
+            ClassicAssert.IsTrue(File.Exists("F130/PERSON.txt"));
+            ClassicAssert.AreEqual("Name: PERSON, CompanyName: Xxx, AppName: Yyy, Properties: Name, Age, Salary", File.ReadAllText("F130/PERSON.txt"));
         }
 
         [Test]
@@ -302,7 +303,7 @@ namespace OnRamp.Test
 
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml") { ExpectNoChanges = true }.AddAssembly(typeof(CodeGeneratorTest).Assembly).AddParameter("Directory", "F140"));
             var ex = Assert.ThrowsAsync<CodeGenChangesFoundException>(() => cg.GenerateAsync("Data/ValidEntity.yaml"));
-            Assert.IsTrue(ex.Message.EndsWith("Person.txt' would be created as a result of the code generation."));
+            ClassicAssert.IsTrue(ex.Message.EndsWith("Person.txt' would be created as a result of the code generation."));
         }
 
         [Test]
@@ -320,24 +321,24 @@ namespace OnRamp.Test
             var cg = await CodeGenerator.CreateAsync(new CodeGeneratorArgs("ValidEntity.yaml") { ExpectNoChanges = true }.AddAssembly(typeof(CodeGeneratorTest).Assembly).AddParameter("Directory", "F150").AddParameter("AppName", "Zzz"));
             var stats = await cg .GenerateAsync("Data/ValidEntity.yaml");
 
-            Assert.NotNull(stats);
-            Assert.AreEqual(0, stats.CreatedCount);
-            Assert.AreEqual(0, stats.UpdatedCount);
-            Assert.AreEqual(4, stats.NotChangedCount);
-            Assert.AreEqual(4, stats.LinesOfCodeCount);
-            Assert.NotNull(stats.ElapsedMilliseconds);
+            ClassicAssert.NotNull(stats);
+            ClassicAssert.AreEqual(0, stats.CreatedCount);
+            ClassicAssert.AreEqual(0, stats.UpdatedCount);
+            ClassicAssert.AreEqual(4, stats.NotChangedCount);
+            ClassicAssert.AreEqual(4, stats.LinesOfCodeCount);
+            ClassicAssert.NotNull(stats.ElapsedMilliseconds);
 
-            Assert.IsTrue(File.Exists("F150/Person.txt"));
-            Assert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F150/Person.txt"));
+            ClassicAssert.IsTrue(File.Exists("F150/Person.txt"));
+            ClassicAssert.AreEqual("Name: Person, CompanyName: Xxx, AppName: Zzz, Properties: Name, Age, Salary", File.ReadAllText("F150/Person.txt"));
 
-            Assert.IsTrue(File.Exists("F150/Name.txt"));
-            Assert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F150/Name.txt"));
+            ClassicAssert.IsTrue(File.Exists("F150/Name.txt"));
+            ClassicAssert.AreEqual("Name: Person.Name, Type: string", File.ReadAllText("F150/Name.txt"));
 
-            Assert.IsTrue(File.Exists("F150/Age.txt"));
-            Assert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F150/Age.txt"));
+            ClassicAssert.IsTrue(File.Exists("F150/Age.txt"));
+            ClassicAssert.AreEqual("Name: Person.Age, Type: int", File.ReadAllText("F150/Age.txt"));
 
-            Assert.IsTrue(File.Exists("F150/Salary.txt"));
-            Assert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F150/Salary.txt"));
+            ClassicAssert.IsTrue(File.Exists("F150/Salary.txt"));
+            ClassicAssert.AreEqual("Name: Person.Salary, Type: decimal?", File.ReadAllText("F150/Salary.txt"));
         }
     }
 }

--- a/tests/OnRamp.Test/Config/EntityConfig.cs
+++ b/tests/OnRamp.Test/Config/EntityConfig.cs
@@ -1,23 +1,22 @@
 ﻿using OnRamp.Config;
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 #nullable enable
 
 namespace OnRamp.Test.Config
 {
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     [CodeGenClass("Entity", Title = "'Entity' object.", Description = "The `Entity` object.", Markdown = "This is a _sample_ markdown.", ExampleMarkdown = "This is an `example` markdown.")]
     [CodeGenCategory("Key", Title = "Provides the _Key_ configuration.")]
     [CodeGenCategory("Collection", Title = "Provides related child (hierarchical) configuration.")]
     public class EntityConfig : ConfigRootBase<EntityConfig>
     {
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         [CodeGenProperty("Key", Title = "The entity name.", IsMandatory = true)]
         public string? Name { get; set; }
 
-        [JsonProperty("properties")]
+        [JsonPropertyName("properties")]
         [CodeGenPropertyCollection("Collection", Title = "The `Property` collection.", IsImportant = true)]
         public List<PropertyConfig>? Properties { get; set; }
 

--- a/tests/OnRamp.Test/Config/PropertyConfig.cs
+++ b/tests/OnRamp.Test/Config/PropertyConfig.cs
@@ -1,27 +1,26 @@
 ﻿using OnRamp.Config;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 #nullable enable
 
 namespace OnRamp.Test.Config
 {
-    [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     [CodeGenClass("Property", Title = "'Property' object.", Description = "The `Property` object.")]
     [CodeGenCategory("Key", Title = "Provides the _Key_ configuration.")]
     public class PropertyConfig : ConfigBase<EntityConfig, EntityConfig>
     {
         public override string QualifiedKeyName => BuildQualifiedKeyName("Property", Name);
 
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         [CodeGenProperty("Key", Title = "The property name.", IsMandatory = true, IsUnique = true)]
         public string? Name { get; set; }
 
-        [JsonProperty("type")]
+        [JsonPropertyName("type")]
         [CodeGenProperty("Key", Title = "The property type.", Description = "This is a more detailed description for the property type.", IsImportant = true, Options = new string[] { "string", "int", "decimal" })]
         public string? Type { get; set; }
 
-        [JsonProperty("isNullable")]
+        [JsonPropertyName("isNullable")]
         [CodeGenProperty("Key", Title = "Indicates whether the property is nullable.")]
         public bool? IsNullable { get; set; }
 

--- a/tests/OnRamp.Test/ConfigRootBaseTest.cs
+++ b/tests/OnRamp.Test/ConfigRootBaseTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OnRamp.Test.Config;
 using System;
 using System.Collections.Generic;
@@ -15,29 +16,29 @@ namespace OnRamp.Test
             var ec = new EntityConfig();
             ec.RuntimeParameters.Add("XXX", "123");
 
-            Assert.AreEqual("123", ec.GetRuntimeParameter("XXX", "456"));
-            Assert.AreEqual(123, ec.GetRuntimeParameter("XXX", 456));
-            Assert.AreEqual("456", ec.GetRuntimeParameter("YYY", "456"));
-            Assert.AreEqual(456, ec.GetRuntimeParameter("YYY", 456));
+            ClassicAssert.AreEqual("123", ec.GetRuntimeParameter("XXX", "456"));
+            ClassicAssert.AreEqual(123, ec.GetRuntimeParameter("XXX", 456));
+            ClassicAssert.AreEqual("456", ec.GetRuntimeParameter("YYY", "456"));
+            ClassicAssert.AreEqual(456, ec.GetRuntimeParameter("YYY", 456));
 
-            Assert.IsTrue(ec.TryGetRuntimeParameter("XXX", out string sv));
-            Assert.AreEqual("123", sv);
+            ClassicAssert.IsTrue(ec.TryGetRuntimeParameter("XXX", out string sv));
+            ClassicAssert.AreEqual("123", sv);
 
-            Assert.IsFalse(ec.TryGetRuntimeParameter("YYY", out sv));
-            Assert.IsNull(sv);
+            ClassicAssert.IsFalse(ec.TryGetRuntimeParameter("YYY", out sv));
+            ClassicAssert.IsNull(sv);
 
-            Assert.IsTrue(ec.TryGetRuntimeParameter("XXX", out int iv));
-            Assert.AreEqual(123, iv);
+            ClassicAssert.IsTrue(ec.TryGetRuntimeParameter("XXX", out int iv));
+            ClassicAssert.AreEqual(123, iv);
 
-            Assert.IsFalse(ec.TryGetRuntimeParameter("YYY", out iv));
-            Assert.AreEqual(0, iv);
+            ClassicAssert.IsFalse(ec.TryGetRuntimeParameter("YYY", out iv));
+            ClassicAssert.AreEqual(0, iv);
 
-            Assert.IsFalse(ec.TryGetRuntimeParameter("YYY", out int? nv));
-            Assert.IsNull(nv);
+            ClassicAssert.IsFalse(ec.TryGetRuntimeParameter("YYY", out int? nv));
+            ClassicAssert.IsNull(nv);
 
             ec.ResetRuntimeParameters();
-            Assert.AreEqual(0, ec.RuntimeParameters.Count);
-            Assert.AreEqual("456", ec.GetRuntimeParameter("XXX", "456"));
+            ClassicAssert.AreEqual(0, ec.RuntimeParameters.Count);
+            ClassicAssert.AreEqual("456", ec.GetRuntimeParameter("XXX", "456"));
         }
 
         [Test]
@@ -54,10 +55,10 @@ namespace OnRamp.Test
             ec.RuntimeParameters.Add("ZZZ", "ABC");
 
             ec.MergeRuntimeParameters(rp);
-            Assert.AreEqual(3, ec.RuntimeParameters.Count);
-            Assert.AreEqual("456", ec.GetRuntimeParameter<string>("XXX"));
-            Assert.AreEqual("789", ec.GetRuntimeParameter<string>("YYY"));
-            Assert.AreEqual("ABC", ec.GetRuntimeParameter<string>("ZZZ"));
+            ClassicAssert.AreEqual(3, ec.RuntimeParameters.Count);
+            ClassicAssert.AreEqual("456", ec.GetRuntimeParameter<string>("XXX"));
+            ClassicAssert.AreEqual("789", ec.GetRuntimeParameter<string>("YYY"));
+            ClassicAssert.AreEqual("ABC", ec.GetRuntimeParameter<string>("ZZZ"));
         }
 
         [Test]
@@ -67,8 +68,8 @@ namespace OnRamp.Test
 
             var ec = new EntityConfig();
             var dtn = ec.DateTimeNow;
-            Assert.IsTrue(dtn > now);
-            Assert.AreEqual(DateTimeKind.Local, dtn.Kind);
+            ClassicAssert.IsTrue(dtn > now);
+            ClassicAssert.AreEqual(DateTimeKind.Local, dtn.Kind);
         }
 
         [Test]
@@ -78,15 +79,15 @@ namespace OnRamp.Test
 
             var ec = new EntityConfig();
             var dtn = ec.DateTimeUtcNow;
-            Assert.IsTrue(dtn > now);
-            Assert.AreEqual(DateTimeKind.Utc, dtn.Kind);
+            ClassicAssert.IsTrue(dtn > now);
+            ClassicAssert.AreEqual(DateTimeKind.Utc, dtn.Kind);
         }
 
         [Test]
         public void NewGuid()
         {
             var ec = new EntityConfig();
-            Assert.AreNotEqual(ec.NewGuid, ec.NewGuid);
+            ClassicAssert.AreNotEqual(ec.NewGuid, ec.NewGuid);
         }
 
         [Test]
@@ -94,9 +95,9 @@ namespace OnRamp.Test
         {
             var ec = new EntityConfig();
             var r = ec.SelectGenResult;
-            Assert.IsNotNull(r);
-            Assert.AreEqual(1, r.Count());
-            Assert.AreSame(ec, r.First());
+            ClassicAssert.IsNotNull(r);
+            ClassicAssert.AreEqual(1, r.Count());
+            ClassicAssert.AreSame(ec, r.First());
         }
     }
 }

--- a/tests/OnRamp.Test/Expected/Schema.json
+++ b/tests/OnRamp.Test/Expected/Schema.json
@@ -4,8 +4,8 @@
   "definitions": {
     "Entity": {
       "type": "object",
-      "title": "'Entity' object.",
-      "description": "The 'Entity' object.",
+      "title": "\u0027Entity\u0027 object.",
+      "description": "The \u0060Entity\u0060 object.",
       "properties": {
         "name": {
           "type": "string",
@@ -13,7 +13,7 @@
         },
         "properties": {
           "type": "array",
-          "title": "The 'Property' collection.",
+          "title": "The \u0060Property\u0060 collection.",
           "items": {
             "$ref": "#/definitions/Property"
           }
@@ -25,8 +25,8 @@
     },
     "Property": {
       "type": "object",
-      "title": "'Property' object.",
-      "description": "The 'Property' object.",
+      "title": "\u0027Property\u0027 object.",
+      "description": "The \u0060Property\u0060 object.",
       "properties": {
         "name": {
           "type": "string",

--- a/tests/OnRamp.Test/HandlebarsHelpersTest.cs
+++ b/tests/OnRamp.Test/HandlebarsHelpersTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OnRamp.Utility;
 using System;
 
@@ -11,195 +12,195 @@ namespace OnRamp.Test
         public void IfEq()
         {
             var g = new HandlebarsCodeGenerator("{{#ifeq Name 'Bob'}}Hi Fella.{{else}}Hi {{Name}}.{{/ifeq}}");
-            Assert.AreEqual("Hi Fella.", g.Generate(new { Name = "Bob" }));
-            Assert.AreEqual("Hi Mary.", g.Generate(new { Name = "Mary" }));
+            ClassicAssert.AreEqual("Hi Fella.", g.Generate(new { Name = "Bob" }));
+            ClassicAssert.AreEqual("Hi Mary.", g.Generate(new { Name = "Mary" }));
         }
 
         [Test]
         public void IfNe()
         {
             var g = new HandlebarsCodeGenerator("{{#ifne Name 'Bob' 'Gary'}}Hi {{Name}}.{{else}}Hi Fella.{{/ifne}}");
-            Assert.AreEqual("Hi Fella.", g.Generate(new { Name = "Bob" }));
-            Assert.AreEqual("Hi Fella.", g.Generate(new { Name = "Gary" }));
-            Assert.AreEqual("Hi Mary.", g.Generate(new { Name = "Mary" }));
+            ClassicAssert.AreEqual("Hi Fella.", g.Generate(new { Name = "Bob" }));
+            ClassicAssert.AreEqual("Hi Fella.", g.Generate(new { Name = "Gary" }));
+            ClassicAssert.AreEqual("Hi Mary.", g.Generate(new { Name = "Mary" }));
         }
 
         [Test]
         public void IfLe()
         {
             var g = new HandlebarsCodeGenerator("{{#ifle Amount -1}}Negative{{else}}Positive{{/ifle}}");
-            Assert.AreEqual("Positive", g.Generate(new { Amount = 1 }));
-            Assert.AreEqual("Positive", g.Generate(new { Amount = 0 }));
-            Assert.AreEqual("Negative", g.Generate(new { Amount = -1 }));
-            Assert.AreEqual("Negative", g.Generate(new { Amount = -2 }));
+            ClassicAssert.AreEqual("Positive", g.Generate(new { Amount = 1 }));
+            ClassicAssert.AreEqual("Positive", g.Generate(new { Amount = 0 }));
+            ClassicAssert.AreEqual("Negative", g.Generate(new { Amount = -1 }));
+            ClassicAssert.AreEqual("Negative", g.Generate(new { Amount = -2 }));
         }
 
         [Test]
         public void IfGe()
         {
             var g = new HandlebarsCodeGenerator("{{#ifge Amount 0}}Positive{{else}}Negative{{/ifge}}");
-            Assert.AreEqual("Positive", g.Generate(new { Amount = 1 }));
-            Assert.AreEqual("Positive", g.Generate(new { Amount = 0 }));
-            Assert.AreEqual("Negative", g.Generate(new { Amount = -1 }));
-            Assert.AreEqual("Negative", g.Generate(new { Amount = -2 }));
+            ClassicAssert.AreEqual("Positive", g.Generate(new { Amount = 1 }));
+            ClassicAssert.AreEqual("Positive", g.Generate(new { Amount = 0 }));
+            ClassicAssert.AreEqual("Negative", g.Generate(new { Amount = -1 }));
+            ClassicAssert.AreEqual("Negative", g.Generate(new { Amount = -2 }));
         }
 
         [Test]
         public void IfVal()
         {
             var g = new HandlebarsCodeGenerator("{{#ifval First Last}}true{{else}}false{{/ifval}}");
-            Assert.AreEqual("false", g.Generate(new { First = (string)null, Last = (string)null }));
-            Assert.AreEqual("false", g.Generate(new { First = "Jane", Last = (string)null }));
-            Assert.AreEqual("false", g.Generate(new { First = (string)null, Last = "Doe" }));
-            Assert.AreEqual("true", g.Generate(new { First = "Jane", Last = "Doe" }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = (string)null, Last = (string)null }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = "Jane", Last = (string)null }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = (string)null, Last = "Doe" }));
+            ClassicAssert.AreEqual("true", g.Generate(new { First = "Jane", Last = "Doe" }));
         }
 
         [Test]
         public void IfNull()
         {
             var g = new HandlebarsCodeGenerator("{{#ifnull First Last}}true{{else}}false{{/ifnull}}");
-            Assert.AreEqual("true", g.Generate(new { First = (string)null, Last = (string)null }));
-            Assert.AreEqual("false", g.Generate(new { First = "Jane", Last = (string)null }));
-            Assert.AreEqual("false", g.Generate(new { First = (string)null, Last = "Doe" }));
-            Assert.AreEqual("false", g.Generate(new { First = "Jane", Last = "Doe" }));
+            ClassicAssert.AreEqual("true", g.Generate(new { First = (string)null, Last = (string)null }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = "Jane", Last = (string)null }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = (string)null, Last = "Doe" }));
+            ClassicAssert.AreEqual("false", g.Generate(new { First = "Jane", Last = "Doe" }));
         }
 
         [Test]
         public void IfOr()
         {
             var g = new HandlebarsCodeGenerator("{{#ifor Val1 Val2}}true{{else}}false{{/ifor}}");
-            Assert.AreEqual("false", g.Generate(new { Val1 = false, Val2 = false }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = false }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = false, Val2 = true }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = true }));
+            ClassicAssert.AreEqual("false", g.Generate(new { Val1 = false, Val2 = false }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = false }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = false, Val2 = true }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = true }));
 
-            Assert.AreEqual("false", g.Generate(new { Val1 = false, Val2 = (string)null }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = (string)null }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = false, Val2 = "X" }));
-            Assert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = "X" }));
+            ClassicAssert.AreEqual("false", g.Generate(new { Val1 = false, Val2 = (string)null }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = (string)null }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = false, Val2 = "X" }));
+            ClassicAssert.AreEqual("true", g.Generate(new { Val1 = true, Val2 = "X" }));
         }
 
         [Test]
         public void Lower()
         {
             var g = new HandlebarsCodeGenerator("{{lower Name}}");
-            Assert.AreEqual("etag", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("etag", g.Generate(new { Name = "ETag" }));
         }
 
         [Test]
         public void Upper()
         {
             var g = new HandlebarsCodeGenerator("{{upper Name}}");
-            Assert.AreEqual("ETAG", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("ETAG", g.Generate(new { Name = "ETag" }));
         }
 
         [Test]
         public void Camel()
         {
             var g = new HandlebarsCodeGenerator("{{camel Name}}");
-            Assert.AreEqual("etag", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("etag", g.Generate(new { Name = "ETag" }));
 
             g = new HandlebarsCodeGenerator("{{camelx Name}}");
-            Assert.AreEqual("eTag", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("eTag", g.Generate(new { Name = "ETag" }));
         }
 
         [Test]
         public void Pascal()
         {
             var g = new HandlebarsCodeGenerator("{{pascal Name}}");
-            Assert.AreEqual("ETag", g.Generate(new { Name = "etag" }));
+            ClassicAssert.AreEqual("ETag", g.Generate(new { Name = "etag" }));
 
             g = new HandlebarsCodeGenerator("{{pascalx Name}}");
-            Assert.AreEqual("Etag", g.Generate(new { Name = "etag" }));
+            ClassicAssert.AreEqual("Etag", g.Generate(new { Name = "etag" }));
         }
 
         [Test]
         public void Private()
         {
             var g = new HandlebarsCodeGenerator("{{private Name}}");
-            Assert.AreEqual("_etag", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("_etag", g.Generate(new { Name = "ETag" }));
 
             g = new HandlebarsCodeGenerator("{{privatex Name}}");
-            Assert.AreEqual("_eTag", g.Generate(new { Name = "ETag" }));
+            ClassicAssert.AreEqual("_eTag", g.Generate(new { Name = "ETag" }));
         }
 
         [Test]
         public void Sentence()
         {
             var g = new HandlebarsCodeGenerator("{{sentence Name}}");
-            Assert.AreEqual("ETag Name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("ETag Name", g.Generate(new { Name = "ETagName" }));
 
             g = new HandlebarsCodeGenerator("{{sentencex Name}}");
-            Assert.AreEqual("E Tag Name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("E Tag Name", g.Generate(new { Name = "ETagName" }));
         }
 
         [Test]
         public void Snake()
         {
             var g = new HandlebarsCodeGenerator("{{snake Name}}");
-            Assert.AreEqual("etag_name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("etag_name", g.Generate(new { Name = "ETagName" }));
 
             g = new HandlebarsCodeGenerator("{{snakex Name}}");
-            Assert.AreEqual("e_tag_name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("e_tag_name", g.Generate(new { Name = "ETagName" }));
         }
 
         [Test]
         public void Kebab()
         {
             var g = new HandlebarsCodeGenerator("{{kebab Name}}");
-            Assert.AreEqual("etag-name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("etag-name", g.Generate(new { Name = "ETagName" }));
 
             g = new HandlebarsCodeGenerator("{{kebabx Name}}");
-            Assert.AreEqual("e-tag-name", g.Generate(new { Name = "ETagName" }));
+            ClassicAssert.AreEqual("e-tag-name", g.Generate(new { Name = "ETagName" }));
         }
 
         [Test]
         public void PastTense()
         {
             var g = new HandlebarsCodeGenerator("{{past-tense Name}}");
-            Assert.AreEqual("Ordered", g.Generate(new { Name = "Order" }));
+            ClassicAssert.AreEqual("Ordered", g.Generate(new { Name = "Order" }));
         }
 
         [Test]
         public void Pluralize()
         {
             var g = new HandlebarsCodeGenerator("{{pluralize Name}}");
-            Assert.AreEqual("Orders", g.Generate(new { Name = "Order" }));
+            ClassicAssert.AreEqual("Orders", g.Generate(new { Name = "Order" }));
         }
 
         [Test]
         public void Singularize()
         {
             var g = new HandlebarsCodeGenerator("{{singularize Name}}");
-            Assert.AreEqual("Order", g.Generate(new { Name = "Orders" }));
+            ClassicAssert.AreEqual("Order", g.Generate(new { Name = "Orders" }));
         }
 
         [Test]
         public void SeeComments()
         {
             var g = new HandlebarsCodeGenerator("{{see-comments Name}}");
-            Assert.AreEqual("<see cref=\"string\"/>", g.Generate(new { Name = "string" }));
+            ClassicAssert.AreEqual("<see cref=\"string\"/>", g.Generate(new { Name = "string" }));
         }
 
         [Test]
         public void Indent()
         {
             var g = new HandlebarsCodeGenerator("{{indent 4}}{{Name}}");
-            Assert.AreEqual("    Bob", g.Generate(new { Name = "Bob" }));
+            ClassicAssert.AreEqual("    Bob", g.Generate(new { Name = "Bob" }));
         }
 
         [Test]
         public void Add()
         {
             var g = new HandlebarsCodeGenerator("{{add 4 '10' Count}}");
-            Assert.AreEqual("12", g.Generate(new { Count = -2 }));
+            ClassicAssert.AreEqual("12", g.Generate(new { Count = -2 }));
         }
 
         [Test]
         public void Add_Index()
         {
             var g = new HandlebarsCodeGenerator("{{#each .}}{{.}}{{add @index 1}}{{/each}}");
-            Assert.AreEqual("a1b2", g.Generate(new System.Collections.Generic.List<string> { "a", "b" }));
+            ClassicAssert.AreEqual("a1b2", g.Generate(new System.Collections.Generic.List<string> { "a", "b" }));
         }
 
         public class SetData { public int Count { get; set; } internal bool Check { get; set; } public decimal Sum { get; set; }  }
@@ -209,12 +210,12 @@ namespace OnRamp.Test
         {
             var sd = new SetData();
             var g = new HandlebarsCodeGenerator("{{set-value 'Count' 88}}");
-            Assert.AreEqual("", g.Generate(sd));
-            Assert.AreEqual(88, sd.Count);
+            ClassicAssert.AreEqual("", g.Generate(sd));
+            ClassicAssert.AreEqual(88, sd.Count);
 
             g = new HandlebarsCodeGenerator("xx{{set-value 'Check' true}}yy");
-            Assert.AreEqual("xxyy", g.Generate(sd));
-            Assert.AreEqual(true, sd.Check);
+            ClassicAssert.AreEqual("xxyy", g.Generate(sd));
+            ClassicAssert.AreEqual(true, sd.Check);
         }
 
         [Test]
@@ -222,12 +223,12 @@ namespace OnRamp.Test
         {
             var sd = new SetData();
             var g = new HandlebarsCodeGenerator("{{add-value 'Sum'}}");
-            Assert.AreEqual("", g.Generate(sd));
-            Assert.AreEqual(1, sd.Sum);
+            ClassicAssert.AreEqual("", g.Generate(sd));
+            ClassicAssert.AreEqual(1, sd.Sum);
 
             g = new HandlebarsCodeGenerator("{{add-value 'Sum' 3 -3.5 '8.4'}}");
-            Assert.AreEqual("", g.Generate(sd));
-            Assert.AreEqual(8.9m, sd.Sum);
+            ClassicAssert.AreEqual("", g.Generate(sd));
+            ClassicAssert.AreEqual(8.9m, sd.Sum);
         }
 
         [Test]
@@ -235,42 +236,42 @@ namespace OnRamp.Test
         {
             var dt = new DateTime(2021, 10, 26, 08, 55, 16);
             var g = new HandlebarsCodeGenerator("Date is {{format '{0:yyyy-MM-dd HH:mm:ss}' Date}}.");
-            Assert.AreEqual($"Date is {dt:yyyy-MM-dd HH:mm:ss}.", g.Generate(new { Date = dt }));
+            ClassicAssert.AreEqual($"Date is {dt:yyyy-MM-dd HH:mm:ss}.", g.Generate(new { Date = dt }));
         }
 
         [Test]
         public void Debug()
         {
             var g = new HandlebarsCodeGenerator("{{debug 'Name: {0}.' Name}}");
-            Assert.AreEqual("", g.Generate(new { Name = "Nancy" }));
+            ClassicAssert.AreEqual("", g.Generate(new { Name = "Nancy" }));
         }
 
         [Test]
         public void LogInfo()
         {
             var g = new HandlebarsCodeGenerator("{{log-info 'Name: {0}.' Name}}");
-            Assert.AreEqual("", g.Generate(new { Name = "Bob" }));
+            ClassicAssert.AreEqual("", g.Generate(new { Name = "Bob" }));
         }
 
         [Test]
         public void LogWarning()
         {
             var g = new HandlebarsCodeGenerator("{{log-warning 'Name: {0}.' Name}}");
-            Assert.AreEqual("", g.Generate(new { Name = "Jane" }));
+            ClassicAssert.AreEqual("", g.Generate(new { Name = "Jane" }));
         }
 
         [Test]
         public void LogError()
         {
             var g = new HandlebarsCodeGenerator("{{log-error 'Name: {0}.' Name}}");
-            Assert.AreEqual("", g.Generate(new { Name = "Bruce" }));
+            ClassicAssert.AreEqual("", g.Generate(new { Name = "Bruce" }));
         }
 
         [Test]
         public void LogDebug()
         {
             var g = new HandlebarsCodeGenerator("{{log-debug 'Name: {0}.' Name}}");
-            Assert.AreEqual("", g.Generate(new { Name = "Grace" }));
+            ClassicAssert.AreEqual("", g.Generate(new { Name = "Grace" }));
         }
     }
 }

--- a/tests/OnRamp.Test/JsonSchemaGeneratorTest.cs
+++ b/tests/OnRamp.Test/JsonSchemaGeneratorTest.cs
@@ -19,8 +19,8 @@ namespace OnRamp.Test
 
             JsonSchemaGenerator.Generate<EntityConfig>(fn, "Entity Configuration");
 
-            Assert.IsTrue(File.Exists(fn));
-            Assert.AreEqual(File.ReadAllText(Path.Combine("Expected", "Schema.json")), File.ReadAllText(fn));
+            Assert.That(File.Exists(fn), Is.True);
+            Assert.That(File.ReadAllText(fn), Is.EqualTo(File.ReadAllText(Path.Combine("Expected", "Schema.json"))));
         }
     }
 }

--- a/tests/OnRamp.Test/MarkdownDocumentationGeneratorTest.cs
+++ b/tests/OnRamp.Test/MarkdownDocumentationGeneratorTest.cs
@@ -18,12 +18,12 @@ namespace OnRamp.Test
             MarkdownDocumentationGenerator.Generate<EntityConfig>(directory: "MSG", addBreaksBetweenSections: true);
 
             var fn = Path.Combine("MSG", "Entity.md");
-            Assert.IsTrue(File.Exists(fn));
-            Assert.AreEqual(File.ReadAllText(Path.Combine("Expected", "Entity.md")), File.ReadAllText(fn));
+            Assert.That(File.Exists(fn), Is.True);
+            Assert.That(File.ReadAllText(fn), Is.EqualTo(File.ReadAllText(Path.Combine("Expected", "Entity.md"))));
 
             fn = Path.Combine("MSG", "Property.md");
-            Assert.IsTrue(File.Exists(fn));
-            Assert.AreEqual(File.ReadAllText(Path.Combine("Expected", "Property.md")), File.ReadAllText(fn));
+            Assert.That(File.Exists(fn), Is.True);
+            Assert.That(File.ReadAllText(fn), Is.EqualTo(File.ReadAllText(Path.Combine("Expected", "Property.md"))));
         }
     }
 }

--- a/tests/OnRamp.Test/OnRamp.Test.csproj
+++ b/tests/OnRamp.Test/OnRamp.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.2.3</Version>
     <Title>Test title.</Title>
     <Description>The long description.</Description>
@@ -64,14 +64,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NUnit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OnRamp.Test/StringConverterTest.cs
+++ b/tests/OnRamp.Test/StringConverterTest.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using OnRamp.Utility;
 
 namespace OnRamp.Test
@@ -9,124 +10,124 @@ namespace OnRamp.Test
         [Test]
         public void ToCamelCase()
         {
-            Assert.AreEqual("fieldName", StringConverter.ToCamelCase("FieldName"));
-            Assert.AreEqual("etagName", StringConverter.ToCamelCase("ETagName"));
-            Assert.AreEqual("odataName", StringConverter.ToCamelCase("ODataName"));
+            ClassicAssert.AreEqual("fieldName", StringConverter.ToCamelCase("FieldName"));
+            ClassicAssert.AreEqual("etagName", StringConverter.ToCamelCase("ETagName"));
+            ClassicAssert.AreEqual("odataName", StringConverter.ToCamelCase("ODataName"));
 
-            Assert.AreEqual("fieldName", StringConverter.ToCamelCase("FieldName", true));
-            Assert.AreEqual("eTagName", StringConverter.ToCamelCase("ETagName", true));
-            Assert.AreEqual("oDataName", StringConverter.ToCamelCase("ODataName", true));
+            ClassicAssert.AreEqual("fieldName", StringConverter.ToCamelCase("FieldName", true));
+            ClassicAssert.AreEqual("eTagName", StringConverter.ToCamelCase("ETagName", true));
+            ClassicAssert.AreEqual("oDataName", StringConverter.ToCamelCase("ODataName", true));
         }
 
         [Test]
         public void ToPascalCase()
         {
-            Assert.AreEqual("FieldName", StringConverter.ToPascalCase("fieldName"));
-            Assert.AreEqual("ETagName", StringConverter.ToPascalCase("etagName"));
-            Assert.AreEqual("ODataName", StringConverter.ToPascalCase("odataName"));
+            ClassicAssert.AreEqual("FieldName", StringConverter.ToPascalCase("fieldName"));
+            ClassicAssert.AreEqual("ETagName", StringConverter.ToPascalCase("etagName"));
+            ClassicAssert.AreEqual("ODataName", StringConverter.ToPascalCase("odataName"));
 
-            Assert.AreEqual("FieldName", StringConverter.ToPascalCase("fieldName", true));
-            Assert.AreEqual("EtagName", StringConverter.ToPascalCase("etagName", true));
-            Assert.AreEqual("OdataName", StringConverter.ToPascalCase("odataName", true));
+            ClassicAssert.AreEqual("FieldName", StringConverter.ToPascalCase("fieldName", true));
+            ClassicAssert.AreEqual("EtagName", StringConverter.ToPascalCase("etagName", true));
+            ClassicAssert.AreEqual("OdataName", StringConverter.ToPascalCase("odataName", true));
         }
 
         [Test]
         public void ToPrivateCase()
         {
-            Assert.AreEqual("_fieldName", StringConverter.ToPrivateCase("FieldName"));
-            Assert.AreEqual("_etagName", StringConverter.ToPrivateCase("ETagName"));
-            Assert.AreEqual("_odataName", StringConverter.ToPrivateCase("ODataName"));
+            ClassicAssert.AreEqual("_fieldName", StringConverter.ToPrivateCase("FieldName"));
+            ClassicAssert.AreEqual("_etagName", StringConverter.ToPrivateCase("ETagName"));
+            ClassicAssert.AreEqual("_odataName", StringConverter.ToPrivateCase("ODataName"));
 
-            Assert.AreEqual("_fieldName", StringConverter.ToPrivateCase("FieldName", true));
-            Assert.AreEqual("_eTagName", StringConverter.ToPrivateCase("ETagName", true));
-            Assert.AreEqual("_oDataName", StringConverter.ToPrivateCase("ODataName", true));
+            ClassicAssert.AreEqual("_fieldName", StringConverter.ToPrivateCase("FieldName", true));
+            ClassicAssert.AreEqual("_eTagName", StringConverter.ToPrivateCase("ETagName", true));
+            ClassicAssert.AreEqual("_oDataName", StringConverter.ToPrivateCase("ODataName", true));
         }
 
         [Test]
         public void ToSentenceCase()
         {
-            Assert.AreEqual("Field Name", StringConverter.ToSentenceCase("FieldName"));
-            Assert.AreEqual("ETag Name", StringConverter.ToSentenceCase("ETagName"));
-            Assert.AreEqual("OData Name", StringConverter.ToSentenceCase("ODataName"));
-            Assert.AreEqual("XML Name", StringConverter.ToSentenceCase("XMLName"));
+            ClassicAssert.AreEqual("Field Name", StringConverter.ToSentenceCase("FieldName"));
+            ClassicAssert.AreEqual("ETag Name", StringConverter.ToSentenceCase("ETagName"));
+            ClassicAssert.AreEqual("OData Name", StringConverter.ToSentenceCase("ODataName"));
+            ClassicAssert.AreEqual("XML Name", StringConverter.ToSentenceCase("XMLName"));
 
-            Assert.AreEqual("Field Name", StringConverter.ToSentenceCase("FieldName", true));
-            Assert.AreEqual("E Tag Name", StringConverter.ToSentenceCase("ETagName", true));
-            Assert.AreEqual("O Data Name", StringConverter.ToSentenceCase("ODataName", true));
-            Assert.AreEqual("XML Name OR Other", StringConverter.ToSentenceCase("XMLNameOROther", true));
+            ClassicAssert.AreEqual("Field Name", StringConverter.ToSentenceCase("FieldName", true));
+            ClassicAssert.AreEqual("E Tag Name", StringConverter.ToSentenceCase("ETagName", true));
+            ClassicAssert.AreEqual("O Data Name", StringConverter.ToSentenceCase("ODataName", true));
+            ClassicAssert.AreEqual("XML Name OR Other", StringConverter.ToSentenceCase("XMLNameOROther", true));
         }
 
         [Test]
         public void ToKebabCase()
         {
-            Assert.AreEqual("field-name", StringConverter.ToKebabCase("FieldName"));
-            Assert.AreEqual("etag-name", StringConverter.ToKebabCase("ETagName"));
-            Assert.AreEqual("odata-name", StringConverter.ToKebabCase("ODataName"));
-            Assert.AreEqual("xml-name", StringConverter.ToKebabCase("XMLName"));
+            ClassicAssert.AreEqual("field-name", StringConverter.ToKebabCase("FieldName"));
+            ClassicAssert.AreEqual("etag-name", StringConverter.ToKebabCase("ETagName"));
+            ClassicAssert.AreEqual("odata-name", StringConverter.ToKebabCase("ODataName"));
+            ClassicAssert.AreEqual("xml-name", StringConverter.ToKebabCase("XMLName"));
 
-            Assert.AreEqual("field-name", StringConverter.ToKebabCase("FieldName", true));
-            Assert.AreEqual("e-tag-name", StringConverter.ToKebabCase("ETagName", true));
-            Assert.AreEqual("o-data-name", StringConverter.ToKebabCase("ODataName", true));
-            Assert.AreEqual("xml-name", StringConverter.ToKebabCase("XMLName", true));
+            ClassicAssert.AreEqual("field-name", StringConverter.ToKebabCase("FieldName", true));
+            ClassicAssert.AreEqual("e-tag-name", StringConverter.ToKebabCase("ETagName", true));
+            ClassicAssert.AreEqual("o-data-name", StringConverter.ToKebabCase("ODataName", true));
+            ClassicAssert.AreEqual("xml-name", StringConverter.ToKebabCase("XMLName", true));
         }
 
         [Test]
         public void ToSnakeCase()
         {
-            Assert.AreEqual("field_name", StringConverter.ToSnakeCase("FieldName"));
-            Assert.AreEqual("etag_name", StringConverter.ToSnakeCase("ETagName"));
-            Assert.AreEqual("odata_name", StringConverter.ToSnakeCase("ODataName"));
-            Assert.AreEqual("xml_name", StringConverter.ToSnakeCase("XMLName"));
+            ClassicAssert.AreEqual("field_name", StringConverter.ToSnakeCase("FieldName"));
+            ClassicAssert.AreEqual("etag_name", StringConverter.ToSnakeCase("ETagName"));
+            ClassicAssert.AreEqual("odata_name", StringConverter.ToSnakeCase("ODataName"));
+            ClassicAssert.AreEqual("xml_name", StringConverter.ToSnakeCase("XMLName"));
 
-            Assert.AreEqual("field_name", StringConverter.ToSnakeCase("FieldName", true));
-            Assert.AreEqual("e_tag_name", StringConverter.ToSnakeCase("ETagName", true));
-            Assert.AreEqual("o_data_name", StringConverter.ToSnakeCase("ODataName", true));
-            Assert.AreEqual("xml_name", StringConverter.ToSnakeCase("XMLName", true));
+            ClassicAssert.AreEqual("field_name", StringConverter.ToSnakeCase("FieldName", true));
+            ClassicAssert.AreEqual("e_tag_name", StringConverter.ToSnakeCase("ETagName", true));
+            ClassicAssert.AreEqual("o_data_name", StringConverter.ToSnakeCase("ODataName", true));
+            ClassicAssert.AreEqual("xml_name", StringConverter.ToSnakeCase("XMLName", true));
         }
 
         [Test]
         public void ToPastTense()
         {
-            Assert.AreEqual("A", StringConverter.ToPastTense("A"));
-            Assert.AreEqual("Be", StringConverter.ToPastTense("Be"));
-            Assert.AreEqual("Pried", StringConverter.ToPastTense("Pry"));
-            Assert.AreEqual("Applied", StringConverter.ToPastTense("Apply"));
-            Assert.AreEqual("Dropped", StringConverter.ToPastTense("Drop"));
-            Assert.AreEqual("Rotted", StringConverter.ToPastTense("Rot"));
-            Assert.AreEqual("Concurred", StringConverter.ToPastTense("Concur"));
-            Assert.AreEqual("Ordered", StringConverter.ToPastTense("Order"));
-            Assert.AreEqual("Sent", StringConverter.ToPastTense("Send"));
-            Assert.AreEqual("sent", StringConverter.ToPastTense("send"));
-            Assert.AreEqual("Frolicked", StringConverter.ToPastTense("Frolic"));
-            Assert.AreEqual("Picnicked", StringConverter.ToPastTense("Picnic"));
+            ClassicAssert.AreEqual("A", StringConverter.ToPastTense("A"));
+            ClassicAssert.AreEqual("Be", StringConverter.ToPastTense("Be"));
+            ClassicAssert.AreEqual("Pried", StringConverter.ToPastTense("Pry"));
+            ClassicAssert.AreEqual("Applied", StringConverter.ToPastTense("Apply"));
+            ClassicAssert.AreEqual("Dropped", StringConverter.ToPastTense("Drop"));
+            ClassicAssert.AreEqual("Rotted", StringConverter.ToPastTense("Rot"));
+            ClassicAssert.AreEqual("Concurred", StringConverter.ToPastTense("Concur"));
+            ClassicAssert.AreEqual("Ordered", StringConverter.ToPastTense("Order"));
+            ClassicAssert.AreEqual("Sent", StringConverter.ToPastTense("Send"));
+            ClassicAssert.AreEqual("sent", StringConverter.ToPastTense("send"));
+            ClassicAssert.AreEqual("Frolicked", StringConverter.ToPastTense("Frolic"));
+            ClassicAssert.AreEqual("Picnicked", StringConverter.ToPastTense("Picnic"));
         }
 
         [Test]
         public void ToPlural()
         {
-            Assert.AreEqual("Castles", StringConverter.ToPlural("Castle"));
-            Assert.AreEqual("Successes", StringConverter.ToPlural("Success"));
+            ClassicAssert.AreEqual("Castles", StringConverter.ToPlural("Castle"));
+            ClassicAssert.AreEqual("Successes", StringConverter.ToPlural("Success"));
         }
 
         [Test]
         public void ToSingle()
         {
-            Assert.AreEqual("Castle", StringConverter.ToSingle("Castles"));
-            Assert.AreEqual("Success", StringConverter.ToSingle("Successes"));
+            ClassicAssert.AreEqual("Castle", StringConverter.ToSingle("Castles"));
+            ClassicAssert.AreEqual("Success", StringConverter.ToSingle("Successes"));
         }
 
         [Test]
         public void ToComments()
         {
-            Assert.AreEqual("See <see cref=\"Xyz\"/>.", StringConverter.ToComments("See {{Xyz}}."));
-            Assert.AreEqual("See <see cref=\"List{Xyz}\"/>.", StringConverter.ToComments("See {{List<Xyz>}}."));
+            ClassicAssert.AreEqual("See <see cref=\"Xyz\"/>.", StringConverter.ToComments("See {{Xyz}}."));
+            ClassicAssert.AreEqual("See <see cref=\"List{Xyz}\"/>.", StringConverter.ToComments("See {{List<Xyz>}}."));
         }
 
         [Test]
         public void ToSeeComments()
         {
-            Assert.AreEqual("<see cref=\"Xyz\"/>", StringConverter.ToSeeComments("Xyz"));
-            Assert.AreEqual("<see cref=\"List{Xyz}\"/>", StringConverter.ToSeeComments("List<Xyz>"));
+            ClassicAssert.AreEqual("<see cref=\"Xyz\"/>", StringConverter.ToSeeComments("Xyz"));
+            ClassicAssert.AreEqual("<see cref=\"List{Xyz}\"/>", StringConverter.ToSeeComments("List<Xyz>"));
         }
     }
 }


### PR DESCRIPTION
- *Enhancement:* **Breaking change** - underlying JSON serialization has been changed from `Newtonsoft.Json` to `System.Text.Json`, with new `Utility.JsonSerializer` encapsulating logic to enable. The following steps are required to migrate existing usage:
  - Rename all attribute references from `JsonProperty` to `JsonPropertyName`.
  - Remove all attribute references to `[JsonObject(MemberSerialization = MemberSerialization.OptIn)]`; opt-in is the default behavior when leveraging the `CodeGenClassAttribute` attribute.
- *Fixed:* All dependencies updated to the latest version.